### PR TITLE
Missing public NavigationController in Coordinator

### DIFF
--- a/RxCoordinator/Sources/Coordinator.swift
+++ b/RxCoordinator/Sources/Coordinator.swift
@@ -29,7 +29,7 @@ extension Coordinator {
         return rootViewController
     }
 
-    var navigationController: UINavigationController {
+    public var navigationController: UINavigationController {
         return viewController as! UINavigationController
     }
 


### PR DESCRIPTION
For access to NavigationController for instance we need this to public