### PR TITLE
dismissalObservable work fixed

### DIFF
--- a/RxCoordinator/Sources/Coordinator.swift
+++ b/RxCoordinator/Sources/Coordinator.swift
@@ -189,7 +189,7 @@ extension Coordinator {
 
     private func dismissalObservable(for viewController: UIViewController) -> Observable<Void> {
         return viewController.rx.sentMessage(#selector(UIViewController.viewWillDisappear))
-            .filter { _ in viewController.isBeingDismissed }
+            .filter { _ in viewController.isBeingDismissed || viewController.isMovingFromParentViewController }
             .map { _ in () }
             .take(1)
     }


### PR DESCRIPTION
Hello, I think that I realised what [problem](https://github.com/quickbirdstudios/RxCoordinator/issues/16) was about and fixed it in this pr.

This is from Apple's documentation:
```
      These four methods can be used in a view controller's appearance callbacks to determine if it is being
      presented, dismissed, or added or removed as a child view controller. For example, a view controller can
      check if it is disappearing because it was dismissed or popped by asking itself in its viewWillDisappear:
      method by checking the expression ([self isBeingDismissed] || [self isMovingFromParentViewController]).
```